### PR TITLE
Fix Seurat 5 compatibility so demos run out-of-the-box

### DIFF
--- a/R/assign_cell_identity.R
+++ b/R/assign_cell_identity.R
@@ -15,10 +15,10 @@ assign_cell_identity <- function(BARCODE, RDS, ASSIGNMETHOD='unique') {
   if (is.character(RDS)) {
     message(paste("Reading RDS file:", RDS))
     RDS= readRDS(RDS)
-  } else {
-    # targetobj = RDS
   }
-  
+  # ensure the object is compatible with the installed Seurat version
+  RDS = UpdateSeuratObject(RDS)
+
   if (ASSIGNMETHOD == "unique") {
 	  
     message("Only assign unique cells")

--- a/R/guidematrix_to_triplet.R
+++ b/R/guidematrix_to_triplet.R
@@ -13,7 +13,9 @@ guidematrix_to_triplet<- function(count_mat, RDS) {
   } else {
     targetobj = RDS
   }
-  
+  # ensure the object is compatible with the installed Seurat version
+  targetobj = UpdateSeuratObject(targetobj)
+
   if (sum(cell_names %in% Cells(RDS))==0) {
     stop("Cell names in guide matrix do not match those in Seurat object. Are columns cell names?")
   }

--- a/R/pre_processRDS.R
+++ b/R/pre_processRDS.R
@@ -22,7 +22,9 @@ pre_processRDS <- function(BARCODE, RDS, normalize = TRUE, scale = TRUE) {
   } else {
     targetobj = RDS
   }
-  
+  # ensure the object is compatible with the installed Seurat version
+  targetobj = UpdateSeuratObject(targetobj)
+
   # check if names are consistent
   nmatch = sum(bc_dox[, 1] %in% colnames(x = targetobj))
   if (nmatch == 0) {

--- a/R/scmageck_best_lambda.R
+++ b/R/scmageck_best_lambda.R
@@ -9,8 +9,10 @@ scmageck_best_lambda <- function(
   if (is.character(rds_object)) {
     message(paste("Reading RDS file:", rds_object))
     rds_object = readRDS(rds_object)
-  } 
-  
+  }
+  # ensure the object is compatible with the installed Seurat version
+  rds_object = UpdateSeuratObject(rds_object)
+
   #randomly select 250 cells expressing non-targeting controls and re-labeled them as a pseudogene
   rds_object_meta = rds_object@meta.data
   rand_df = rds_object_meta[sample(nrow(rds_object_meta), size=pseudogene_num), ]

--- a/R/scmageck_eff_estimate.R
+++ b/R/scmageck_eff_estimate.R
@@ -15,7 +15,9 @@ scmageck_eff_estimate<-function(rds_object, bc_frame, perturb_gene, non_target_c
   if (is.character(rds_object)) {
     message(paste("Reading RDS file:", rds_object))
     rds_object = readRDS(rds_object)
-  } 
+  }
+  # ensure the object is compatible with the installed Seurat version
+  rds_object = UpdateSeuratObject(rds_object)
 
   if (is.character(bc_frame)) {
     bc_frame = read.table(bc_frame, header = TRUE, as.is = TRUE)

--- a/R/scmageck_lr.R
+++ b/R/scmageck_lr.R
@@ -47,6 +47,8 @@ scmageck_lr <- function(BARCODE, RDS, NEGCTRL, SELECT_GENE = NULL, LABEL = NULL,
   } else {
     targetobj = RDS
   }
+  # ensure the object is compatible with the installed Seurat version
+  targetobj = UpdateSeuratObject(targetobj)
   # check if names are consistent 
   nmatch = sum(bc_dox[, 'cell'] %in% colnames(x = targetobj))
   if (nmatch == 0) {

--- a/R/scmageck_rra.R
+++ b/R/scmageck_rra.R
@@ -3,17 +3,11 @@ scmageck_rra <- function(BARCODE, RDS, GENE, RRAPATH = NULL, LABEL = NULL, NEGCT
   message('Testing Rcpp:')
   #z=rcpp_hello_world()
   #message(str(z))
-  if (is.null(RRAPATH)) {
-    RRAPATH = system.file("bin", "RRA", package = "scMAGeCK")
-  }
-  message("Checking RRA...")
-  if (!file.exists(RRAPATH)) {
-    if (system('RRA', ignore.stdout = TRUE, ignore.stderr = TRUE)!=0) {
-      message("RRA does not exist! Please check RRA executable file path")
-      #return(NULL)
-    } else {
-      RRAPATH=NULL # if RRA already exists
-    }
+  # Since v1.5.1 the RRA algorithm is built in via Rcpp (call_rra); no external
+  # RRA executable is required. Only validate a user-supplied RRAPATH.
+  if (!is.null(RRAPATH) && !file.exists(RRAPATH)) {
+    message("Provided RRAPATH not found; falling back to the built-in RRA.")
+    RRAPATH = NULL
   }
   if (!is.null(LABEL)) {
     data_label = LABEL
@@ -82,6 +76,8 @@ scmageck_rra <- function(BARCODE, RDS, GENE, RRAPATH = NULL, LABEL = NULL, NEGCT
   } else {
     targetobj = RDS
   }
+  # ensure the object is compatible with the installed Seurat version
+  targetobj = UpdateSeuratObject(targetobj)
   # check if names are consistent
   nmatch = sum(bc_dox[, 1] %in% colnames(x = targetobj))
   if (nmatch == 0) {

--- a/R/violin_plot.R
+++ b/R/violin_plot.R
@@ -1,5 +1,7 @@
 violin_plot <- function(BARCODE, GENE, sgRNA, RDS, CONTROL = NULL) {
   pbmc <- readRDS(RDS)
+  # ensure the object is compatible with the installed Seurat version
+  pbmc <- UpdateSeuratObject(pbmc)
   barcode <- read.delim(BARCODE)
   target_gene_list = strsplit(GENE, ",")[[1]]
   target_gene_list = trimws(target_gene_list)


### PR DESCRIPTION
## Problem

On a fresh install with current Seurat (tested on 5.3.1), **both flagship demos fail immediately**:

```
Error in slot(object = object, name = s) :
  no slot of name "images" for this object of class "Seurat"
```

The bundled demo object `inst/extdata/singles_dox_mki67_v3.RDS` is a **Seurat v3.0.0** object serialized before the `images` slot existed. Every entry point does `readRDS()` and hands the object straight to Seurat 5 accessors (`colnames`, `ncol`, `GetAssayData`), which require slots the old object lacks. `UpdateSeuratObject()` was not called anywhere in the package.

## Changes

1. **Seurat-version compatibility (blocking bug).** Call `UpdateSeuratObject()` immediately after the object is read/received in all 8 entry points: `scmageck_rra`, `scmageck_lr`, `scmageck_eff_estimate`, `scmageck_best_lambda`, `pre_processRDS`, `assign_cell_identity`, `guidematrix_to_triplet`, `violin_plot`. It's an idempotent no-op on already-current objects.

2. **Remove obsolete external-RRA probe (misleading UX).** Since v1.5.1 the RRA algorithm is built in via Rcpp (`call_rra`), yet `scmageck_rra()` still ran `system('RRA')` and printed `RRA does not exist! Please check RRA executable file path` on every run. `RRAPATH` is now only validated when the user explicitly supplies one.

## Verification

With these changes the **unmodified** `demo/demo1_scmageck_R/scmageck_rra_demo.R` and `scmageck_lr_demo.R` (from the bitbucket demos repo) run to completion on Seurat 5.3.1:

- RRA → `RRA completed.`, writes `dox_mki67_MKI67_RRA.txt` (MKI67 signal `p.high ≈ 5e-06`)
- LR → 1000/1000 permutations, writes score + pval tables

`scmageck_rra`, `scmageck_lr`, and `scmageck_eff_estimate` were exercised end-to-end; the remaining sites received the identical mechanical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)