### PR TITLE
Fix defunct GetAssayData/FetchData slot= argument (SeuratObject >= 5)

### DIFF
--- a/R/featurePlot.R
+++ b/R/featurePlot.R
@@ -82,7 +82,7 @@ featurePlot <- function(RDS, TYPE = plot.type, BARCODE = NULL, sgRNA = NULL, GEN
       }
       
       if (length(target_gene_list) == 1) {
-        data <- FetchData(RDS, GENE, slot = SLOT)  #the values indicate log(TPM)
+        data <- FetchData(RDS, GENE, layer = SLOT)  #the values indicate log(TPM)
         colnames(data)[1] <- paste("genes")
       } else {
         #data <- FetchData(RDS, target_gene_list[1], slot = SLOT)
@@ -99,7 +99,7 @@ featurePlot <- function(RDS, TYPE = plot.type, BARCODE = NULL, sgRNA = NULL, GEN
             message(paste('Warning: the following genes are missing in expression assays. Skip these genes.'))
             message(paste(target_gene_list [ ! target_gene_list %in% rownames(RDS)], collapse=','))
         }
-        data <- FetchData(RDS, tgls, slot = SLOT)
+        data <- FetchData(RDS, tgls, layer = SLOT)
         data$genes <- rowMeans(data)
       }
       
@@ -181,7 +181,7 @@ featurePlot <- function(RDS, TYPE = plot.type, BARCODE = NULL, sgRNA = NULL, GEN
         target_sgrna_list = strsplit(sgRNA, ",")[[1]]
         target_sgrna_list = trimws(target_sgrna_list)
         target_sgrna_list <-  paste("sgrna_", target_sgrna_list, sep = "")
-        grna <- FetchData(RDS, target_sgrna_list,slot=SLOT)
+        grna <- FetchData(RDS, target_sgrna_list, layer = SLOT)
       }
         grna$grna <- rowSums(grna)
         grna <- subset(grna, grna > 0)

--- a/R/getscaledata.R
+++ b/R/getscaledata.R
@@ -17,7 +17,8 @@ getscaledata <- function(targetobj,  slot = c("data", "scale.data", "counts")) {
     #        scalef = GetAssayData(object = targetobj, slot = "counts")
     #    }
     #}
-    scalef = GetAssayData(object = targetobj, slot = slot)
+    # 'layer' replaces the 'slot' argument, which is defunct in SeuratObject >= 5
+    scalef = GetAssayData(object = targetobj, layer = slot)
     return(scalef)
 }
 TRUE


### PR DESCRIPTION
## Problem

The Bitbucket master pipeline (and any user on current Seurat) fails with:

```
Error: The `slot` argument of `GetAssayData()` was deprecated in SeuratObject 5.0.0 and is now defunct.
  scmageck_rra(...) -> getscaledata(targetobj, slot = SLOT) -> GetAssayData(object = targetobj, slot = slot)
Error: processing vignette 'scMAGeCK.Rmd' failed  ->  Vignette re-building failed.
```

`slot=` on `GetAssayData()` and `FetchData()` was deprecated in SeuratObject 5.0.0 and became **defunct (a hard error) in SeuratObject 5.4+**. It surfaces in `R CMD build` because the vignette runs `scmageck_rra`/`scmageck_lr`, and it breaks those functions (via `getscaledata`) plus `featurePlot` for any user on a recent Seurat. Older Seurat (≤ 5.3) only *warned*, which is why it wasn't caught earlier.

## Fix

Replace `slot =` with `layer =` — the current API, available since SeuratObject 5.0 (already the package's minimum via `Seurat (>= 5.0.0)`):
- `getscaledata()`: `GetAssayData(..., layer = slot)`
- `featurePlot()`: `FetchData(..., layer = SLOT)` (3 call sites)

## Verification

Reproduced the exact failure in an isolated env with **SeuratObject 5.4.0** (where `slot=` is defunct), then with the fix:
- `scmageck_rra_demo.R` and `scmageck_lr_demo.R` → run to completion, **0 defunct errors**, output tables produced.
- The vignette **knits cleanly** (`knitr::knit` → md with RRA output); the only remaining local build step needing pandoc is environmental (CI installs it).

Pairs with the Bitbucket CI change that moves the pipeline to a Seurat 5 image — both are needed for the master pipeline to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)