### PR TITLE
Compiled-code stdout fix + set Wei Li as maintainer (Bioc)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Identify genes associated with multiple expression phenotypes in single-c
 Version: 0.99.0
 Date: 2026-07-09
 Authors@R: c(
-    person("Wei", "Li", role = "aut"),
-    person("Xiaolong", "Cheng", email = "xiaolongcheng1120@gmail.com", role = c("aut", "cre")),
+    person("Wei", "Li", email = "li.david.wei@gmail.com", role = c("aut", "cre")),
+    person("Xiaolong", "Cheng", email = "xiaolongcheng1120@gmail.com", role = "aut"),
     person("Lin", "Yang", role = "aut"))
 Description: scMAGeCK is a computational model to identify genes associated with multiple expression phenotypes from CRISPR screening coupled with single-cell RNA sequencing data (CROP-seq).
 License: BSD_2_clause + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,4 +8,7 @@
     `FetchData()` with `layer=` (defunct in SeuratObject >= 5.4).
   - The bundled example object is now stored in the Seurat v5 format.
 * `DESCRIPTION` now requires `Seurat (>= 5.0.0)`.
+* Compiled code (RRA) now writes diagnostics to the R console via
+  `Rcpp::Rcout`/`Rcpp::Rcerr`/`Rprintf` instead of `std::cout`/`printf`.
+* R CMD check / BiocCheck clean-up (dead code, namespace, docs, examples).
 * Version reset to 0.99.0 for Bioconductor resubmission.

--- a/src/RRA.cpp
+++ b/src/RRA.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <iostream>
 #include <fstream>
+#include <Rcpp.h>
 #include <algorithm>
 
 using namespace std;
@@ -100,7 +101,7 @@ int loadControlSeq(const char* fname){
   ifstream fh;
   fh.open(fname);
   if(!fh.is_open()){
-    cerr<<"Error opening "<<fname<<endl;
+    Rcpp::Rcerr<<"Error opening "<<fname<<endl;
   }
   string oneline;
   int ncount=0;
@@ -113,7 +114,7 @@ int loadControlSeq(const char* fname){
     }
     //oneline.erase( remove(oneline.begin(), oneline.end(), '\r'), oneline.end() );
     //oneline.erase( remove(oneline.begin(), oneline.end(), '\n'), oneline.end() );
-    //cout<<oneline<<"#"<<oneline.size()<<endl;
+    //Rcpp::Rcout<<oneline<<"#"<<oneline.size()<<endl;
     ControlSeqMap[oneline]=ncount;
 
     ncount++;
@@ -121,7 +122,7 @@ int loadControlSeq(const char* fname){
   fh.close();
   ControlSeqPercentile = new double[ncount];
   for(int i=0;i<ncount;i++) ControlSeqPercentile[i]=-1.0;
-  cout<<ControlSeqMap.size()<<" control sequences loaded.\n";
+  Rcpp::Rcout<<ControlSeqMap.size()<<" control sequences loaded.\n";
   return 0;
 }
 
@@ -147,7 +148,7 @@ int RRA_main (vector<string> & argv) {
     return 0;
   }
   
-  printf("Welcome to RRA v %s.\n", RRA_VERSION);
+  Rprintf("Welcome to RRA v %s.\n", RRA_VERSION);
   inputFileName[0] = 0;
   outputFileName[0] = 0;
   maxPercentile = 0.1;
@@ -182,7 +183,7 @@ int RRA_main (vector<string> & argv) {
      }
      if (argv[i-1] == "--skip-gene"){
 	string sn(argv[i]);
-	cout<<"Skipping gene "<<sn<<" for permutation ..."<<endl;
+	Rcpp::Rcout<<"Skipping gene "<<sn<<" for permutation ..."<<endl;
        gene_to_skip[sn]=0;
      }
      if (argv[i-1] == "--min-percentage-goodsgrna"){
@@ -204,19 +205,19 @@ int RRA_main (vector<string> & argv) {
   
   if ((inputFileName[0]==0)||(outputFileName[0]==0))
   {
-    cerr<<"Error: input file or output file name not set.\n";
+    Rcpp::Rcerr<<"Error: input file or output file name not set.\n";
     PrintCommandUsage(argv[0].c_str());
     return -1;
   }
   
   if ((maxPercentile>1.0)||(maxPercentile<0.0))
   {
-    cerr<<("Error: maxPercentile should be within 0.0 and 1.0\n");
+    Rcpp::Rcerr<<("Error: maxPercentile should be within 0.0 and 1.0\n");
     return -1;
   }
   if ((minPercentile>1.0))
   {
-    cerr<<("Error: minPercentile should be less than 1.0\n");
+    Rcpp::Rcerr<<("Error: minPercentile should be less than 1.0\n");
     return -1;
   }
   
@@ -225,28 +226,28 @@ int RRA_main (vector<string> & argv) {
   assert(groups!=NULL);
   assert(lists!=NULL);
   
-  printf("Reading input file...\n");
+  Rprintf("Reading input file...\n");
   
   flag = ReadFile(inputFileName, groups, MAX_GROUP_NUM, &groupNum, lists, MAX_LIST_NUM, &listNum);
   
   if (flag<=0){
-    cerr<<"\nError: reading ranking file ...\n";
+    Rcpp::Rcerr<<"\nError: reading ranking file ...\n";
     return -1;
   }
   
-  cerr<<("Computing lo-values for each group...\n");
+  Rcpp::Rcerr<<("Computing lo-values for each group...\n");
   
   if (ProcessGroups(groups, groupNum, lists, listNum, minPercentile, maxPercentile)<=0)
   {
-      cerr<<("\nError: processing groups failed.\n");
+      Rcpp::Rcerr<<("\nError: processing groups failed.\n");
       return -1;
   }
   	
-  cerr<<("Computing false discovery rate...\n");
+  Rcpp::Rcerr<<("Computing false discovery rate...\n");
   	
   if(rand_passnum*groupNum<100000  && has_specified_rand_passnum_parameter==false){
     rand_passnum=100000/groupNum+1;
-    cout<<"Increase the number of permutations to "<<rand_passnum<<" to get precise p values. To avoid this, use the --permutation option.\n";
+    Rcpp::Rcout<<"Increase the number of permutations to "<<rand_passnum<<" to get precise p values. To avoid this, use the --permutation option.\n";
   }
   
   if(permutation_by_group){
@@ -256,26 +257,26 @@ int RRA_main (vector<string> & argv) {
   }
   if (i<=0)
   {
-     cerr<<("\nError: computing FDR failed.\n");
+     Rcpp::Rcerr<<("\nError: computing FDR failed.\n");
      return -1;
   }
   adjustFDR(groups,groupNum);
   	
-  cerr<<("Saving to output file...\n");
+  Rcpp::Rcerr<<("Saving to output file...\n");
   
   if (SaveGroupInfo(outputFileName, groups, groupNum)<=0)
   {
-     cerr<<("\nError: saving output file failed.\n");
+     Rcpp::Rcerr<<("\nError: saving output file failed.\n");
      return -1;
   }
   	
-  cerr<<("RRA completed.\n");
+  Rcpp::Rcerr<<("RRA completed.\n");
   
     for(i=0;i<groupNum;i++)
       delete[] groups[i].items;
     free(groups);
 
-    cerr<<("Groups deletion complete.\n");
+    Rcpp::Rcerr<<("Groups deletion complete.\n");
   
     for (i=0;i<listNum;i++)
     {
@@ -283,10 +284,10 @@ int RRA_main (vector<string> & argv) {
     }
     free(lists);
 
-    cerr<<("Lists deletion complete.\n");
+    Rcpp::Rcerr<<("Lists deletion complete.\n");
 
     if(UseControlSeq){
-       cerr<<("ControlSeqPercentile deletion complete.\n");
+       Rcpp::Rcerr<<("ControlSeqPercentile deletion complete.\n");
        delete[] ControlSeqPercentile;
     }
   
@@ -298,21 +299,21 @@ int RRA_main (vector<string> & argv) {
 void PrintCommandUsage(const char *command)
 {
 	//print the options of the command
-	printf("%s - Robust Rank Aggreation v %s.\n", command, RRA_VERSION);
-	printf("usage:\n");
-	printf("-i <input data file>. Format: <item id> <group id> <list id> <value> [<probability>] [<chosen>]\n");
-	printf("-o <output file>. Format: <group id> <number of items in the group> <lo-value> <false discovery rate>\n");
-	printf("-p <maximum percentile>. RRA only consider the items with percentile smaller than this parameter. Default=0.1\n");
-	printf("-P <minimum percentile>. RRA only consider the items with percentile greater than this parameter. Default=-1.0\n");
-	printf("--control <control_sgrna list>. A list of control sgRNA names.\n");
-	printf("--permutation <int>. The number of rounds of permutation. Increase this value if the number of genes is small. Default 100.\n");
-	printf("--no-permutation-by-group. By default, gene permutation is performed separately, by their number of sgRNAs. Turning this option will perform permutation on all genes together. This makes the program faster, but the p value estimation is accurate only if the number of sgRNAs per gene is approximately the same.\n");
-	printf("--skip-gene <gene_name>. Genes to skip from doing permutation. Specify it multiple times if you need to skip more than 1 genes.\n");
-	printf("--min-percentage-goodsgrna <min percentage>. Filter genes that have too few percentage of 'good sgrnas', or sgrnas that fall below the -p threshold. Must be a number between 0-1. Default 0 (do not filter genes).\n");
-	printf("--min-number-goodsgrna <min number>. Filter genes that have too few number of 'good sgrnas', or sgrnas that fall below the -p threshold. Must be an integer. Default 0 (do not filter genes). \n");
-	printf("--max-sgrnapergene-permutation <max number>. Only permute genes by group if the number of sgRNAs per gene is smaller than this number. This will save a lot of time if some regions are targeted by a large number of sgRNAs (usually hundreds). Must be an integer. Default 100. \n");
-	printf("example:\n");
-	printf("%s -i input.txt -o output.txt -p 0.1 \n", command);
+	Rprintf("%s - Robust Rank Aggreation v %s.\n", command, RRA_VERSION);
+	Rprintf("usage:\n");
+	Rprintf("-i <input data file>. Format: <item id> <group id> <list id> <value> [<probability>] [<chosen>]\n");
+	Rprintf("-o <output file>. Format: <group id> <number of items in the group> <lo-value> <false discovery rate>\n");
+	Rprintf("-p <maximum percentile>. RRA only consider the items with percentile smaller than this parameter. Default=0.1\n");
+	Rprintf("-P <minimum percentile>. RRA only consider the items with percentile greater than this parameter. Default=-1.0\n");
+	Rprintf("--control <control_sgrna list>. A list of control sgRNA names.\n");
+	Rprintf("--permutation <int>. The number of rounds of permutation. Increase this value if the number of genes is small. Default 100.\n");
+	Rprintf("--no-permutation-by-group. By default, gene permutation is performed separately, by their number of sgRNAs. Turning this option will perform permutation on all genes together. This makes the program faster, but the p value estimation is accurate only if the number of sgRNAs per gene is approximately the same.\n");
+	Rprintf("--skip-gene <gene_name>. Genes to skip from doing permutation. Specify it multiple times if you need to skip more than 1 genes.\n");
+	Rprintf("--min-percentage-goodsgrna <min percentage>. Filter genes that have too few percentage of 'good sgrnas', or sgrnas that fall below the -p threshold. Must be a number between 0-1. Default 0 (do not filter genes).\n");
+	Rprintf("--min-number-goodsgrna <min number>. Filter genes that have too few number of 'good sgrnas', or sgrnas that fall below the -p threshold. Must be an integer. Default 0 (do not filter genes). \n");
+	Rprintf("--max-sgrnapergene-permutation <max number>. Only permute genes by group if the number of sgRNAs per gene is smaller than this number. This will save a lot of time if some regions are targeted by a large number of sgRNAs (usually hundreds). Must be an integer. Default 100. \n");
+	Rprintf("example:\n");
+	Rprintf("%s -i input.txt -o output.txt -p 0.1 \n", command);
 	
 }
 
@@ -381,7 +382,7 @@ int ProcessGroups(GROUP_STRUCT *groups, int groupNum, LIST_STRUCT *lists, int li
     if(validsgs<=1){
       isallone=true;
     }
-    //printf("Gene: %s\n",groups[i].name);
+    //Rprintf("Gene: %s\n",groups[i].name);
     if(isallone){
       ComputeLoValue(tmpF, validsgs, groups[i].loValue, minPercentile,maxPercentile, groups[i].goodsgrnas);
     }else{
@@ -392,7 +393,7 @@ int ProcessGroups(GROUP_STRUCT *groups, int groupNum, LIST_STRUCT *lists, int li
       if(groups[i].controlsgs==groups[i].itemNum){
 	string sn(groups[i].name);
         gene_to_skip[sn]=1;
-	cout<<"Skipping gene "<<sn<<" for permutation ..."<<endl;
+	Rcpp::Rcout<<"Skipping gene "<<sn<<" for permutation ..."<<endl;
       }
     }
   }//end i loop
@@ -403,7 +404,7 @@ int ProcessGroups(GROUP_STRUCT *groups, int groupNum, LIST_STRUCT *lists, int li
   if(UseControlSeq){
     for(map<string,int>::iterator mit = ControlSeqMap.begin(); mit != ControlSeqMap.end(); mit++){
       if(ControlSeqPercentile[mit->second]<0){
-        cerr<<"Warning: sgRNA "<<mit->first<<" not found in the ranked list. \n";
+        Rcpp::Rcerr<<"Warning: sgRNA "<<mit->first<<" not found in the ranked list. \n";
         //ControlSeqPercentile[mit->second]=0.5;
       }
     }
@@ -526,12 +527,12 @@ int ComputeLoValue_Prob(double *percentiles,     //array of percentiles
   }
 
   
-  if(PRINT_DEBUG) printf("probs:");
+  if(PRINT_DEBUG) Rprintf("probs:");
   for(i=0;i<num;i++)
   {
-    if(PRINT_DEBUG) printf("%f,",probValue[i]);
+    if(PRINT_DEBUG) Rprintf("%f,",probValue[i]);
   }
-  if(PRINT_DEBUG) printf("\n");
+  if(PRINT_DEBUG) Rprintf("\n");
 
   accuLoValue=0.0;
   for (pid=1;pid<(1<<num);pid++)
@@ -571,10 +572,10 @@ int ComputeLoValue_Prob(double *percentiles,     //array of percentiles
       }
       real_i = real_i + 1;
      }
-    if(PRINT_DEBUG) printf("pid: %d, prob:%e, score: %f\n",pid,c_prob,tmpLoValue);
+    if(PRINT_DEBUG) Rprintf("pid: %d, prob:%e, score: %f\n",pid,c_prob,tmpLoValue);
     accuLoValue=accuLoValue+tmpLoValue*c_prob;
   }
-  if(PRINT_DEBUG) printf("total: %f\n",accuLoValue);
+  if(PRINT_DEBUG) Rprintf("total: %f\n",accuLoValue);
 
   loValue = accuLoValue;
 
@@ -596,7 +597,7 @@ int adjustFDR(GROUP_STRUCT *groups, int groupNum){
       ngn++;
     }
   }
-  cout<<"Number of genes under FDR adjustment: "<<ngn<<endl;
+  Rcpp::Rcout<<"Number of genes under FDR adjustment: "<<ngn<<endl;
   vector<double> pvalue_in;
   for(i=0;i<groupNum;i++){
     if(groups[i].isbad==0){
@@ -689,14 +690,14 @@ int ComputePermutationbyNumSG(GROUP_STRUCT *groups, int groupNum, double minPerc
         n_control++;
       }
     }
-    cout<<"Total # control sgRNAs: "<<n_control<<endl;
+    Rcpp::Rcout<<"Total # control sgRNAs: "<<n_control<<endl;
   }
   
   for(map<int,int>::iterator mii=itemNumMap.begin();mii!=itemNumMap.end();mii++){
     int sgrnanum=mii->first;
     if(sgrnanum<=max_sgnum_permutation_by_group){// to avoid permutations on genes with too many sgRNAs (take too much time)
       randLoValueNum = 0;
-      cout<<"Permuting genes with "<<sgrnanum<<" sgRNAs..."<<endl;
+      Rcpp::Rcout<<"Permuting genes with "<<sgrnanum<<" sgRNAs..."<<endl;
       for (i=0;i<scanPass;i++){
         for (j=0;j<groupNum;j++){
           int validsgs=0;
@@ -844,7 +845,7 @@ int ComputePermutation(GROUP_STRUCT *groups, int groupNum, double minPercentile,
         n_control++;
       }
     }
-    cout<<"Total # control sgRNAs: "<<n_control<<endl;
+    Rcpp::Rcout<<"Total # control sgRNAs: "<<n_control<<endl;
   }
   
   for (i=0;i<scanPass;i++){

--- a/src/RRA.cpp
+++ b/src/RRA.cpp
@@ -102,15 +102,18 @@ int loadControlSeq(const char* fname){
   fh.open(fname);
   if(!fh.is_open()){
     Rcpp::Rcerr<<"Error opening "<<fname<<endl;
+    return -1;
   }
   string oneline;
   int ncount=0;
   ControlSeqMap.clear();
   while(!fh.eof()){
     getline(fh,oneline);
-    char nc =oneline[oneline.size() - 1];
-    if (!oneline.empty() && (nc== '\r' || nc =='\n')){
-      oneline.erase(oneline.size() - 1);
+    if (!oneline.empty()){
+      char nc =oneline[oneline.size() - 1];
+      if (nc== '\r' || nc =='\n'){
+        oneline.erase(oneline.size() - 1);
+      }
     }
     //oneline.erase( remove(oneline.begin(), oneline.end(), '\r'), oneline.end() );
     //oneline.erase( remove(oneline.begin(), oneline.end(), '\n'), oneline.end() );
@@ -299,7 +302,7 @@ int RRA_main (vector<string> & argv) {
 void PrintCommandUsage(const char *command)
 {
 	//print the options of the command
-	Rprintf("%s - Robust Rank Aggreation v %s.\n", command, RRA_VERSION);
+	Rprintf("%s - Robust Rank Aggregation v %s.\n", command, RRA_VERSION);
 	Rprintf("usage:\n");
 	Rprintf("-i <input data file>. Format: <item id> <group id> <list id> <value> [<probability>] [<chosen>]\n");
 	Rprintf("-o <output file>. Format: <group id> <number of items in the group> <lo-value> <false discovery rate>\n");

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -38,10 +38,11 @@ int getGroupListNum(char* fileName, GROUP_STRUCT* &groups, LIST_STRUCT* lists, i
   fh.open(fileName);
   if(!fh.is_open()){
     Rcpp::Rcerr<<"Error opening "<<fileName<<endl;
+    return -1;
   }
   string oneline;
   getline(fh,oneline);
-  
+
   vector<string> vwords;
   vector<string> vsubwords;
   wordNum=stringSplit(oneline," \t\r\n\v",vwords);
@@ -180,8 +181,9 @@ int ReadFile(char *fileName, GROUP_STRUCT* &groups, int maxGroupNum, int *groupN
   fh.open(fileName);
   if(!fh.is_open()){
     Rcpp::Rcerr<<"Error opening "<<fileName<<endl;
+    return -1;
   }
-	
+
 	//Read the header row to get the sample number
   getline(fh,oneline);
 	//fgets(tmpS, MAX_WORD_NUM*(MAX_NAME_LEN+1)*sizeof(char), fh);
@@ -290,7 +292,7 @@ int SaveGroupInfo(char *fileName, GROUP_STRUCT *groups, int groupNum)
   
   for (i=0;i<groupNum;i++){
     if(groups[i].controlsgs>=groups[i].itemNum){ //skip those that consists of only control sgrnas
-      Rprintf("Suppressing the output of gene %s since it is negative ontrol genes.\n",groups[i].name);
+      Rprintf("Suppressing the output of gene %s since it consists only of negative control sgRNAs.\n",groups[i].name);
       continue;
     }
     if(groups[i].isbad==0){

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <iostream>
 #include <fstream>
+#include <Rcpp.h>
 using namespace std;
 
 #include "fileio.h"
@@ -36,7 +37,7 @@ int getGroupListNum(char* fileName, GROUP_STRUCT* &groups, LIST_STRUCT* lists, i
   ifstream fh;
   fh.open(fileName);
   if(!fh.is_open()){
-    cerr<<"Error opening "<<fileName<<endl;
+    Rcpp::Rcerr<<"Error opening "<<fileName<<endl;
   }
   string oneline;
   getline(fh,oneline);
@@ -48,7 +49,7 @@ int getGroupListNum(char* fileName, GROUP_STRUCT* &groups, LIST_STRUCT* lists, i
   //fgets(tmpS, MAX_WORD_NUM*(MAX_NAME_LEN+1)*sizeof(char), fh);
   //wordNum = StringToWords(words, tmpS,MAX_WORD_NUM, MAX_NAME_LEN+1,  " \t\r\n\v\f");
   if (wordNum < 4 || wordNum > 6){
-    cerr<<"Error: incorrect input file format: <item id> <group id> <list id> <value> [<prob>] [iscounted]\n";
+    Rcpp::Rcerr<<"Error: incorrect input file format: <item id> <group id> <list id> <value> [<prob>] [iscounted]\n";
     fh.close();
     return -1;
   }
@@ -84,7 +85,7 @@ int getGroupListNum(char* fileName, GROUP_STRUCT* &groups, LIST_STRUCT* lists, i
          groupNames[subwstr]=tmpGroupNum;
          tmpGroupNum ++;
          if (tmpGroupNum >= maxGroupNum){
-           printf("Warning: too many groups; maxGroupNum = %d\n. Will try to double the maximum number of groups..", maxGroupNum);
+           Rprintf("Warning: too many groups; maxGroupNum = %d\n. Will try to double the maximum number of groups..", maxGroupNum);
            GROUP_STRUCT* gp2=new GROUP_STRUCT[maxGroupNum*2];
 	   memcpy(gp2,groups,maxGroupNum*sizeof(GROUP_STRUCT));
 	   delete []groups;
@@ -108,7 +109,7 @@ int getGroupListNum(char* fileName, GROUP_STRUCT* &groups, LIST_STRUCT* lists, i
       listNames[thisliststr]=tmpListNum;
       tmpListNum ++;
       if (tmpListNum >= maxListNum){
-        printf("Error: too many lists. maxListNum = %d\n", maxListNum);
+        Rprintf("Error: too many lists. maxListNum = %d\n", maxListNum);
         return -1;
       }
     }
@@ -162,14 +163,14 @@ int ReadFile(char *fileName, GROUP_STRUCT* &groups, int maxGroupNum, int *groupN
   }
   // construct the structure
 	for (i=0;i<tmpGroupNum;i++){
-    //printf("Group %d items:%d\n",i,groups[i].itemNum);
+    //Rprintf("Group %d items:%d\n",i,groups[i].itemNum);
 		groups[i].items = new ITEM_STRUCT[groups[i].itemNum];
 		groups[i].maxItemNum = groups[i].itemNum;
 		groups[i].itemNum = 0;
 	}
 	
 	for (i=0;i<tmpListNum;i++){
-    //printf("List %d items:%d\n",i,lists[i].itemNum);
+    //Rprintf("List %d items:%d\n",i,lists[i].itemNum);
 		lists[i].values = new double[lists[i].itemNum]; 
 		lists[i].maxItemNum = lists[i].itemNum;
 		lists[i].itemNum = 0;
@@ -178,7 +179,7 @@ int ReadFile(char *fileName, GROUP_STRUCT* &groups, int maxGroupNum, int *groupN
   // actually loading the file
   fh.open(fileName);
   if(!fh.is_open()){
-    cerr<<"Error opening "<<fileName<<endl;
+    Rcpp::Rcerr<<"Error opening "<<fileName<<endl;
   }
 	
 	//Read the header row to get the sample number
@@ -252,13 +253,13 @@ int ReadFile(char *fileName, GROUP_STRUCT* &groups, int maxGroupNum, int *groupN
 		//wordNum = StringToWords(words, tmpS, MAX_NAME_LEN+1, MAX_WORD_NUM, " \t\r\n\v\f");
     getline(fh,oneline);
     wordNum=stringSplit(oneline," \t\r\f\v",vwords);
-   	//printf("wordnum:%d,read one line length:%d\n",wordNum,strlen(tmpS));
+   	//Rprintf("wordnum:%d,read one line length:%d\n",wordNum,strlen(tmpS));
 	}//end loop for fh reading
 	
 	fh.close();
 	//fclose(fh);
 	
-	printf("Summary: %d sgRNAs, %d genes, %d lists; skipped sgRNAs:%d\n", totalItemNum, tmpGroupNum, tmpListNum,skippedsgrna);
+	Rprintf("Summary: %d sgRNAs, %d genes, %d lists; skipped sgRNAs:%d\n", totalItemNum, tmpGroupNum, tmpListNum,skippedsgrna);
 	
 	*groupNum = tmpGroupNum;
 	*listNum = tmpListNum;
@@ -281,7 +282,7 @@ int SaveGroupInfo(char *fileName, GROUP_STRUCT *groups, int groupNum)
   fh = (FILE *)fopen(fileName, "w");
   
   if (!fh){
-    printf("Cannot open %s.\n", fileName);
+    Rprintf("Cannot open %s.\n", fileName);
     return -1;
   }
   
@@ -289,7 +290,7 @@ int SaveGroupInfo(char *fileName, GROUP_STRUCT *groups, int groupNum)
   
   for (i=0;i<groupNum;i++){
     if(groups[i].controlsgs>=groups[i].itemNum){ //skip those that consists of only control sgrnas
-      printf("Suppressing the output of gene %s since it is negative ontrol genes.\n",groups[i].name);
+      Rprintf("Suppressing the output of gene %s since it is negative ontrol genes.\n",groups[i].name);
       continue;
     }
     if(groups[i].isbad==0){

--- a/src/rngs.cpp
+++ b/src/rngs.cpp
@@ -33,6 +33,7 @@
  */
 
 #include <stdio.h>
+#include <R_ext/Print.h>
 #include <time.h>
 #include "rngs.h"
 
@@ -116,11 +117,11 @@ static int  initialized   = 0;          /* test for stream initialization */
     x = ((unsigned long) time((time_t *) NULL)) % MODULUS;              
   if (x == 0)                                
     while (!ok) {
-      printf("\nEnter a positive integer seed (9 digits or less) >> ");
+      Rprintf("\nEnter a positive integer seed (9 digits or less) >> ");
       scanf("%ld", &x);
       ok = (0 < x) && (x < MODULUS);
       if (!ok)
-        printf("\nInput out of range ... try again\n");
+        Rprintf("\nInput out of range ... try again\n");
     }
   seed[stream] = x;
 }
@@ -173,7 +174,7 @@ static int  initialized   = 0;          /* test for stream initialization */
   GetSeed(&x);                      /* get the state of stream 1       */
   ok = ok && (x == A256);           /* x should be the jump multiplier */    
   if (ok)
-    printf("\n The implementation of rngs.c is correct.\n\n");
+    Rprintf("\n The implementation of rngs.c is correct.\n\n");
   else
-    printf("\n\a ERROR -- the implementation of rngs.c is not correct.\n\n");
+    Rprintf("\n\a ERROR -- the implementation of rngs.c is not correct.\n\n");
 }

--- a/src/rngs.cpp
+++ b/src/rngs.cpp
@@ -104,25 +104,17 @@ static int  initialized   = 0;          /* test for stream initialization */
  * Use this function to set the state of the current random number 
  * generator stream according to the following conventions:
  *    if x > 0 then x is the state (unless too large)
- *    if x < 0 then the state is obtained from the system clock
- *    if x = 0 then the state is to be supplied interactively
+ *    if x <= 0 then the state is obtained from the system clock
  * ---------------------------------------------------------------
+ * Note: reading a seed interactively from stdin is not safe inside an
+ * R package (it would hang non-interactive/batch runs), so x == 0 is
+ * treated the same as x < 0 (seed from the clock).
  */
 {
-  char ok = 0;
-
   if (x > 0)
     x = x % MODULUS;                       /* correct if x is too large  */
-  if (x < 0)                                 
-    x = ((unsigned long) time((time_t *) NULL)) % MODULUS;              
-  if (x == 0)                                
-    while (!ok) {
-      Rprintf("\nEnter a positive integer seed (9 digits or less) >> ");
-      scanf("%ld", &x);
-      ok = (0 < x) && (x < MODULUS);
-      if (!ok)
-        Rprintf("\nInput out of range ... try again\n");
-    }
+  if (x <= 0)
+    x = ((unsigned long) time((time_t *) NULL)) % MODULUS;
   seed[stream] = x;
 }
 


### PR DESCRIPTION
Final Bioconductor submission-readiness for 0.99.0.

- **Compiled code → R console**: `std::cout`/`cerr`/`printf` → `Rcpp::Rcout`/`Rcpp::Rcerr`/`Rprintf` in `src/RRA.cpp`/`fileio.cpp`/`rngs.cpp` (the `fprintf(fh, ...)` result-file writes are unchanged). Clears the last R CMD check NOTE.
- **Maintainer** set to Wei Li <li.david.wei@gmail.com> (`cre`); Xiaolong Cheng and Lin Yang remain `aut`.
- **Copilot review follow-ups**: early-return on file-open failure (`loadControlSeq`/`getGroupListNum`/`ReadFile`); guard empty-line char access (UB); `PutSeed(0)` seeds from the clock instead of reading stdin via `scanf`; fixed two message typos.

**Verified**: `scMAGeCK.so` no longer references `std::cout`/`cerr`/`printf`/`puts`/`putchar`; `scmageck_rra` on the bundled demo is byte-identical (`all.equal` == TRUE; lo_value sums + control-seq count unchanged); R CMD check on Linux = 0 ERROR / 0 WARNING / 0 NOTE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)